### PR TITLE
Fix GitHub issue template for documentation issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/good_first_issue_doc.yaml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue_doc.yaml
@@ -8,15 +8,17 @@ body:
       value: |
         ## 👋 Thanks for contributing to MailLogSentinel!
         
-        ⚠️ **Code issues only** - for docs/tests, use the other templates
+        ⚠️ **Docs issues only** - for codes/tests, use the other templates
         
         **Perfect for**: first-time contributors, non-developers, improving adoption
         
         ⏱️ **Estimated time**: 1-3h | **No Python code required**
 
         📖 Before you begin:
-        - [README](../blob/main/README.md) | [CONTRIBUTING](../blob/main/docs/CONTRIBUTING.md) | [Wiki](../wiki)
-        - [Code de conduite](../blob/main/CODE_OF_CONDUCT.md)
+        - [ ] [README](../blob/main/README.md) (optional)
+        - [ ] [CONTRIBUTING](../blob/main/docs/CONTRIBUTING.md) (mandatory)
+        - [ ] [Wiki](../wiki) (optional)
+        - [ ] [Code of conduct](../blob/main/CODE_OF_CONDUCT.md) (mandatory)
 
   - type: dropdown
     id: doc_type
@@ -28,6 +30,8 @@ body:
         - "Code docstrings"
         - "Examples/Tutorials"
         - "FAQ/Troubleshooting"
+        - "Templates"
+        - "Others"
     validations:
       required: true
 
@@ -70,7 +74,9 @@ body:
     id: files_to_modify
     attributes:
       label: "📋 Files to modify"
-      placeholder: "README.md, docs/setup.md, etc."
+      placeholder: "- [ ] README.md
+- [ ] docs/setup.md
+- [ ] etc."
       description: "Which files will be impacted?"
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/good_first_issue_doc.yaml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue_doc.yaml
@@ -14,11 +14,17 @@ body:
         
         ⏱️ **Estimated time**: 1-3h | **No Python code required**
 
-        📖 Before you begin:
-        - [ ] [README](../blob/main/README.md) (optional)
-        - [ ] [CONTRIBUTING](../blob/main/docs/CONTRIBUTING.md) (mandatory)
-        - [ ] [Wiki](../wiki) (optional)
-        - [ ] [Code of conduct](../blob/main/CODE_OF_CONDUCT.md) (mandatory)
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: "📖 Before you begin"
+      options:
+        - label: "README"
+        - label: "CONTRIBUTING"
+          required: true
+        - label: "Wiki"
+        - label: "Code of conduct"
+          required: true
 
   - type: dropdown
     id: doc_type
@@ -31,6 +37,7 @@ body:
         - "Examples/Tutorials"
         - "FAQ/Troubleshooting"
         - "Templates"
+        - "Workflows"
         - "Others"
     validations:
       required: true
@@ -74,9 +81,7 @@ body:
     id: files_to_modify
     attributes:
       label: "📋 Files to modify"
-      placeholder: "- [ ] README.md
-- [ ] docs/setup.md
-- [ ] etc."
+      placeholder: "README.md\ndocs/setup.md\netc."
       description: "Which files will be impacted?"
 
   - type: textarea


### PR DESCRIPTION
🎯 Type of documentation
Examples / Tutorials
#28 
🐛 Identified user problem
The "Before you begin" section needs changes: it should be a checkbox list, with CONTRIBUTING and CODE OF CONDUCT marked as mandatory.

The documentation template currently has two errors:

⚠️ Code issues only — should be Docs issues only.

[Code de conduite](https://github.com/monozoide/MailLogSentinel/blob/main/CODE_OF_CONDUCT.md) — should be [Code of conduct](https://github.com/monozoide/MailLogSentinel/blob/main/CODE_OF_CONDUCT.md).

Also, the Type of documentation dropdown should include:

- Templates
- Workflows
- Others

📍 Target audience

Users

Contributors

Maintainers

📋 Suggested content outline / changes

Modify Before you begin: convert into a checkbox list with CONTRIBUTING and CODE OF CONDUCT as mandatory.

Fix the template .github/ISSUE_TEMPLATE/good_first_issue_doc.yaml:
1.  Line 11: replace ⚠️ Code issues only - for docs/tests, use the other templates → ⚠️ Docs issues only - for codes/tests, use the other templates.
3. Line 19: replace [Code de conduite] → [Code of conduct].
4. Line 30: add dropdown options: Templates and Others.
5. Line 73: change the example placeholder to checklist format.

📂 Expected deliverables

Markdown text for the updated template

Screenshots/examples (if applicable)

Links to external resources

Review feedback from a test user

📋 Files to modify

.github/ISSUE_TEMPLATE/good_first_issue_doc.yaml

✅ How to validate the result

We will check it together to ensure:

"Before you begin" section has proper checkboxes

Warning text shows "Docs issues only"

Dropdown options include Templates and Others

Example placeholder is a checklist

All text is in English