### PR TITLE
update github action workflow #34

### DIFF
--- a/.github/workflows/mls-ci.yml
+++ b/.github/workflows/mls-ci.yml
@@ -1,0 +1,85 @@
+name: MLS ci
+
+on:
+  pull_request:
+    branches: [ main, dev ]
+  push:
+    branches: [ main, dev ]
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: detect-changes
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '!docs/**'
+              - '!**/*.md'
+              - '!**/*.mdx'
+              - '!**/*.png'
+              - '!**/*.jpg'
+              - '!**/*.jpeg'
+              - '!**/*.gif'
+              - '!**/*.svg'
+              - '!**/*.yaml'
+              - '!**/*.yml'
+              - '**'
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+      - run: python -m pip install --upgrade pip
+      - run: |
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install flake8
+      - name: flake8
+        run: |
+          flake8 . --count --select=E9,F63,F7,F82,F821,F823,F824 --show-source --statistics
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+  tests:
+    name: tests
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+      - run: python -m pip install --upgrade pip
+      - run: |
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+      - name: pytest
+        run: |
+          export PYTHONPATH=$PYTHONPATH:.
+          pytest --maxfail=1 --disable-warnings -q
+
+  docs-only:
+    name: docs-only fast-path
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code_changed != 'true'
+    steps:
+      - run: echo "Docs-only change → skipping lint/tests ✅"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 __pycache__/
 *.pyc
-*.log
 logs/
 # Test artifacts
 /tests/__pycache__/

--- a/tests/sample_data/logs_en_test/mail_sample_en_test.log
+++ b/tests/sample_data/logs_en_test/mail_sample_en_test.log
@@ -1,0 +1,3 @@
+Feb  2 02:00:00 hostB postfix/smtpd[200]: client=unknown[4.4.4.4], sasl_method=PLAIN, sasl_username=user_en1@example.com
+Feb  2 02:00:01 hostB postfix/smtpd[201]: client=unknown[5.5.5.5], sasl_method=LOGIN, sasl_username=user_en2@example.com
+Feb  2 02:00:02 hostB postfix/smtpd[202]: client=unknown[6.6.6.6], sasl_method=PLAIN, sasl_username=user_en3@example.com

--- a/tests/sample_data/logs_ft/mail_sample_ft.log
+++ b/tests/sample_data/logs_ft/mail_sample_ft.log
@@ -1,0 +1,3 @@
+Jan  1 01:00:00 hostA postfix/smtpd[100]: client=unknown[1.1.1.1], sasl_method=PLAIN, sasl_username=user1@example.com
+Jan  1 01:00:01 hostA postfix/smtpd[101]: client=unknown[2.2.2.2], sasl_method=LOGIN, sasl_username=user2@example.com
+Jan  1 01:00:02 hostA postfix/smtpd[102]: client=unknown[3.3.3.3], sasl_method=PLAIN, sasl_username=user3@example.com


### PR DESCRIPTION
Updated .gitignore to allow .log files in the repository for test data.

## Purpose of this PR
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring / Code quality
- [x] CI-Tests

### Description
Currently, during a merge, a Github Action job is executed for each PR, regardless of the files being pushed.

Following the implementation of protections for the main and dev branches, the workflow needs to be modified to exclude any verification of documentation-related files and text files after a PR.

It is also necessary to split the 2 jobs (lint and test) for better maintenance (there was only one job for both).

### How to test?

1. When validating a PR, the workflow begins by identifying which files to merge. All documentation-related files (*.md, *.txt, *.log, *.png, etc.) are excluded to speed up the process.
2. Two parallel jobs are then executed: lint and tests.

<img width="891" height="350" alt="image" src="https://github.com/user-attachments/assets/abcbc1e0-dd35-4215-8642-0a87f5f4f682" />


### Checklist
- [x] Local tests pass (`pytest`)
- [ ] Documentation/README updated if necessary
- [x] Link to issue: Closes #34 
- [x] No breaking changes (or documented)